### PR TITLE
refined CUJ1 benchmark

### DIFF
--- a/perfkitbenchmarker/data/edw/bigquery/search_index/CUJ1/check_index_coverage_query
+++ b/perfkitbenchmarker/data/edw/bigquery/search_index/CUJ1/check_index_coverage_query
@@ -1,0 +1,8 @@
+SELECT
+  *
+FROM
+  `p3rf-bq-search`.`search_index_dataset`.INFORMATION_SCHEMA.SEARCH_INDEXES
+WHERE
+  table_name = 'prototype_CUJ1_benchmarking_100GB' 
+AND 
+  coverage_percentage = 100;

--- a/perfkitbenchmarker/data/edw/bigquery/search_index/CUJ1/check_index_coverage_query
+++ b/perfkitbenchmarker/data/edw/bigquery/search_index/CUJ1/check_index_coverage_query
@@ -1,3 +1,4 @@
+-- TODO: Remove hardcoded table name
 SELECT
   *
 FROM

--- a/perfkitbenchmarker/data/edw/bigquery/search_index/CUJ1/check_index_coverage_query
+++ b/perfkitbenchmarker/data/edw/bigquery/search_index/CUJ1/check_index_coverage_query
@@ -3,6 +3,6 @@ SELECT
 FROM
   `p3rf-bq-search`.`search_index_dataset`.INFORMATION_SCHEMA.SEARCH_INDEXES
 WHERE
-  table_name = 'prototype_CUJ1_benchmarking_100GB' 
+  table_name = 'prototype_CUJ1_benchmark_100GB' 
 AND 
   coverage_percentage = 100;

--- a/perfkitbenchmarker/data/edw/bigquery/search_index/CUJ1/create_index_query
+++ b/perfkitbenchmarker/data/edw/bigquery/search_index/CUJ1/create_index_query
@@ -1,0 +1,2 @@
+CREATE SEARCH INDEX IF NOT EXISTS prototype_CUJ1_benchmark_index
+ON prototype_CUJ1_benchmarking_100GB(ALL COLUMNS);

--- a/perfkitbenchmarker/data/edw/bigquery/search_index/CUJ1/create_index_query
+++ b/perfkitbenchmarker/data/edw/bigquery/search_index/CUJ1/create_index_query
@@ -1,2 +1,3 @@
+-- TODO: Remove hardcoded table name
 CREATE SEARCH INDEX IF NOT EXISTS prototype_CUJ1_benchmark_index
 ON prototype_CUJ1_benchmark_100GB(ALL COLUMNS);

--- a/perfkitbenchmarker/data/edw/bigquery/search_index/CUJ1/create_index_query
+++ b/perfkitbenchmarker/data/edw/bigquery/search_index/CUJ1/create_index_query
@@ -1,2 +1,2 @@
 CREATE SEARCH INDEX IF NOT EXISTS prototype_CUJ1_benchmark_index
-ON prototype_CUJ1_benchmarking_100GB(ALL COLUMNS);
+ON prototype_CUJ1_benchmark_100GB(ALL COLUMNS);

--- a/perfkitbenchmarker/data/edw/bigquery/search_index/CUJ1/delete_index_query
+++ b/perfkitbenchmarker/data/edw/bigquery/search_index/CUJ1/delete_index_query
@@ -1,1 +1,1 @@
-DROP SEARCH INDEX IF EXISTS prototype_CUJ1_benchmark_index ON prototype_CUJ1_benchmarking_100GB;
+DROP SEARCH INDEX IF EXISTS prototype_CUJ1_benchmark_index ON prototype_CUJ1_benchmark_100GB;

--- a/perfkitbenchmarker/data/edw/bigquery/search_index/CUJ1/delete_index_query
+++ b/perfkitbenchmarker/data/edw/bigquery/search_index/CUJ1/delete_index_query
@@ -1,1 +1,2 @@
+-- TODO: Remove hardcoded table name
 DROP SEARCH INDEX IF EXISTS prototype_CUJ1_benchmark_index ON prototype_CUJ1_benchmark_100GB;

--- a/perfkitbenchmarker/data/edw/bigquery/search_index/CUJ1/delete_index_query
+++ b/perfkitbenchmarker/data/edw/bigquery/search_index/CUJ1/delete_index_query
@@ -1,0 +1,1 @@
+DROP SEARCH INDEX IF EXISTS prototype_CUJ1_benchmark_index ON prototype_CUJ1_benchmarking_100GB;

--- a/perfkitbenchmarker/data/edw/bigquery/search_index/CUJ1/verify_no_index_query
+++ b/perfkitbenchmarker/data/edw/bigquery/search_index/CUJ1/verify_no_index_query
@@ -1,3 +1,4 @@
+-- TODO: Remove hardcoded table name
 SELECT
   *
 FROM

--- a/perfkitbenchmarker/data/edw/bigquery/search_index/CUJ1/verify_no_index_query
+++ b/perfkitbenchmarker/data/edw/bigquery/search_index/CUJ1/verify_no_index_query
@@ -3,6 +3,4 @@ SELECT
 FROM
   `p3rf-bq-search`.`search_index_dataset`.INFORMATION_SCHEMA.SEARCH_INDEXES
 WHERE
-  table_name = 'prototype_simple_shuninglin_100GB' 
-AND 
-  coverage_percentage = 100;
+  table_name = 'prototype_CUJ1_benchmarking_100GB' 

--- a/perfkitbenchmarker/data/edw/bigquery/search_index/CUJ1/verify_no_index_query
+++ b/perfkitbenchmarker/data/edw/bigquery/search_index/CUJ1/verify_no_index_query
@@ -3,4 +3,4 @@ SELECT
 FROM
   `p3rf-bq-search`.`search_index_dataset`.INFORMATION_SCHEMA.SEARCH_INDEXES
 WHERE
-  table_name = 'prototype_CUJ1_benchmarking_100GB' 
+  table_name = 'prototype_CUJ1_benchmark_100GB' 

--- a/perfkitbenchmarker/data/edw/bigquery/search_index/create_index/create_index_query
+++ b/perfkitbenchmarker/data/edw/bigquery/search_index/create_index/create_index_query
@@ -1,2 +1,0 @@
-CREATE SEARCH INDEX IF NOT EXISTS prototype_simple_creation_benchmark_index
-ON prototype_simple_shuninglin_100GB(ALL COLUMNS);

--- a/perfkitbenchmarker/data/edw/bigquery/search_index/delete_index/delete_index_query
+++ b/perfkitbenchmarker/data/edw/bigquery/search_index/delete_index/delete_index_query
@@ -1,1 +1,0 @@
-DROP SEARCH INDEX IF EXISTS prototype_simple_creation_benchmark_index ON prototype_simple_shuninglin_100GB;

--- a/perfkitbenchmarker/linux_benchmarks/edw_create_index_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/edw_create_index_benchmark.py
@@ -13,44 +13,7 @@
 # limitations under the License.
 
 """
-
-Run command:
-
-BigQuery:
-
-./pkb.py \
---cloud=GCP  \
---benchmarks=edw_create_index_benchmark \
---bq_client_interface=PYTHON  \
---config_override=edw_create_index_benchmark.edw_service.type=bigquery \
---config_override=edw_create_index_benchmark.edw_service.cluster_identifier=p3rf-bq-search.search_index_dataset \
---gcp_service_account=bigquery-testing-pkb@p3rf-bigquery-smallquery-slots.iam.gserviceaccount.com \
---gcp_service_account_key_file=/home/shuninglin/p3rf-bq-search-050c6559ed66.json \
---edw_index_creation_query_dir=edw/bigquery/search_index/CUJ1 \
---edw_power_queries=verify_no_index_query,create_index_query,delete_index_query,check_index_coverage_query \
---metadata=cloud:GCP \
---project=p3rf-bq-search \
---zones=us-central1-c 
-
-Snowflake:
-
-TODO: Add SF queries to query folder and set up SF tables.
-
-./pkb.py \
---cloud=AWS \
---benchmarks=edw_create_index_benchmark \
---snowflake_client_interface=JDBC  \
---config_override=edw_create_index_benchmark.edw_service.type=snowflake_aws \
---config_override=edw_index_benchmark.edw_service.cluster_identifier= \
---snowflake_database=SEARCH_INDEX \
---snowflake_schema=INDEX_TEST \
---snowflake_warehouse=XSMALL_TEST \
---edw_index_creation_query_dir=edw/snowflake_aws/search_index/CUJ1 \
---edw_power_queries=verify_no_index_query,create_index_query,delete_index_query,check_index_coverage_query \
---metadata=cloud:AWS \
---snowflake_jdbc_client_jar=/home/shuninglin/snowflake-jdbc-client-2.13-enterprise.jar \
---machine_type=m4.large \
---zones=us-west-2a
+TODO: Set up SF tables and queries and test if they work.
 """
 
 """Benchmark for creating an index in an EDW service."""

--- a/perfkitbenchmarker/linux_benchmarks/edw_create_index_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/edw_create_index_benchmark.py
@@ -85,7 +85,7 @@ def Prepare(benchmark_spec: bm_spec.BenchmarkSpec) -> None:
   any(vm.PushDataFile(query_loc) for query_loc in query_locations)
 
 
-def ensure_no_index(
+def _EnsureNoIndex(
     client_interface: edw_service.EdwClientInterface, timeout: int = 30
 ) -> None:
   """Checks if an index already exists and deletes it if it does.
@@ -109,7 +109,7 @@ def ensure_no_index(
     time.sleep(1)
 
 
-def create_index(
+def _CreateIndex(
     client_interface: edw_service.EdwClientInterface,
     results: list[sample.Sample],
 ) -> None:
@@ -127,7 +127,7 @@ def create_index(
   )
 
 
-def measure_building_time(
+def _MeasureBuildingTime(
     client_interface: edw_service.EdwClientInterface,
     results: list[sample.Sample],
     timeout: int = 120,
@@ -173,11 +173,11 @@ def Run(benchmark_spec: bm_spec.BenchmarkSpec) -> list[sample.Sample]:
   edw_service_instance = benchmark_spec.edw_service
   client_interface = edw_service_instance.GetClientInterface()
 
-  ensure_no_index(client_interface)
+  _EnsureNoIndex(client_interface)
 
-  create_index(client_interface, results)
+  _CreateIndex(client_interface, results)
 
-  measure_building_time(client_interface, results)
+  _MeasureBuildingTime(client_interface, results)
 
   return results
 

--- a/perfkitbenchmarker/linux_benchmarks/edw_create_index_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/edw_create_index_benchmark.py
@@ -22,13 +22,14 @@ import os
 import time
 import logging
 from absl import flags
+from typing import Any
 from perfkitbenchmarker import configs
-from perfkitbenchmarker import edw_service
 from perfkitbenchmarker import sample
-from perfkitbenchmarker import vm_util
+from perfkitbenchmarker import edw_service
+from perfkitbenchmarker import benchmark_spec as bm_spec
+
 
 BENCHMARK_NAME = 'edw_create_index_benchmark'
-
 BENCHMARK_CONFIG = """
 edw_create_index_benchmark:
   description: Benchmark for creating an index in an EDW service.
@@ -50,12 +51,19 @@ flags.DEFINE_string(
 FLAGS = flags.FLAGS
 
 
-def GetConfig(user_config):
-  """Loads and returns the benchmark config."""
+def GetConfig(user_config: dict[Any, Any]) -> dict[Any, Any]:
+  """Load and return benchmark config.
+
+  Args:
+    user_config: user supplied configuration (flags and config file)
+
+  Returns:
+    loaded benchmark configuration
+  """
   return configs.LoadConfig(BENCHMARK_CONFIG, user_config, BENCHMARK_NAME)
 
 
-def Prepare(benchmark_spec):
+def Prepare(benchmark_spec: bm_spec.BenchmarkSpec) -> None:
   """Prepares the client VM to run the benchmark.
 
   Args:
@@ -77,15 +85,20 @@ def Prepare(benchmark_spec):
   any(vm.PushDataFile(query_loc) for query_loc in query_locations)
 
 
-# Check if there's an index already created. If so, issue a command to delete the index and keep
-# checking until index is deleted or timeout
-def ensure_no_index(client_interface):
+def ensure_no_index(
+    client_interface: edw_service.EdwClientInterface, timeout: int = 30
+) -> None:
+  """Checks if an index already exists and deletes it if it does.
+
+  Args:
+    client_interface: The EDW client interface.
+    timeout: The maximum time(in seconds) to wait for the index to be deleted.
+  """
   start_time = time.time()
-  timeout = 30
   while True:
     time_elapsed = time.time() - start_time
     if time_elapsed > timeout:
-      logging.error("Timed out waiting for index to be deleted.")
+      logging.error('Timed out waiting for index to be deleted.')
       # TODO: find a way to stop the benchmark in case of timeout
       break
     _, metadata = client_interface.ExecuteQuery('verify_no_index_query')
@@ -93,44 +106,69 @@ def ensure_no_index(client_interface):
       client_interface.ExecuteQuery('delete_index_query')
     else:
       break
-    time.sleep(1) 
+    time.sleep(1)
 
 
-# Create the index
-def create_index(client_interface, results):
+def create_index(
+    client_interface: edw_service.EdwClientInterface,
+    results: list[sample.Sample],
+) -> None:
+  """Creates an index and records the execution time.
+
+  Args:
+    client_interface: The EDW client interface.
+    results: The list of samples to append to.
+  """
   execution_time, metadata = client_interface.ExecuteQuery('create_index_query')
-  results.append(sample.Sample('search_index_creation_time', execution_time, 'seconds', metadata))
+  results.append(
+      sample.Sample(
+          'search_index_creation_time', execution_time, 'seconds', metadata
+      )
+  )
 
 
-# Check Index Coverage until it reaches 100, record the time of reaching 100.
-# Time out if it takes too long to reach 100
-def measure_building_time(client_interface, results):
+def measure_building_time(
+    client_interface: edw_service.EdwClientInterface,
+    results: list[sample.Sample],
+    timeout: int = 120,
+) -> None:
+  """Measures the time it takes for the index to be fully built(reaching 100% coverage).
+
+  Args:
+    client_interface: The EDW client interface.
+    results: The list of samples to append to.
+    timeout: The maximum time(in seconds) to wait for the index to be fully built.
+  """
   start_time = time.time()
-  timeout = 120
   while True:
     _, metadata = client_interface.ExecuteQuery('check_index_coverage_query')
     time_elapsed = time.time() - start_time
     if metadata and metadata.get('rows_returned', 0) > 0:
-      results.append(sample.Sample('search_index_available_time', time_elapsed, 'seconds', metadata))
+      results.append(
+          sample.Sample(
+              'search_index_available_time', time_elapsed, 'seconds', metadata
+          )
+      )
       break
     if time_elapsed > timeout:
-      logging.error("Timed out waiting for index to fully cover the table.")
+      logging.error('Timed out waiting for index to fully cover the table.')
       # TODO: find a way to stop the benchmark in case of timeout
       break
     else:
-      time.sleep(1) 
+      time.sleep(1)
 
 
-def Run(benchmark_spec):
+def Run(benchmark_spec: bm_spec.BenchmarkSpec) -> list[sample.Sample]:
   """Runs the benchmark and returns a list of samples.
 
   Args:
-    benchmark_spec: The benchmark specification.
+    benchmark_spec: The benchmark specification. Contains all data that is
+    required to run the benchmark.
 
   Returns:
     A list of sample.Sample objects.
   """
-  results = []
+  results: list[sample.Sample] = []
 
   edw_service_instance = benchmark_spec.edw_service
   client_interface = edw_service_instance.GetClientInterface()
@@ -144,13 +182,14 @@ def Run(benchmark_spec):
   return results
 
 
-def Cleanup(benchmark_spec):
+def Cleanup(benchmark_spec: bm_spec.BenchmarkSpec) -> None:
   """Cleans up the benchmark resources.
 
   Args:
     benchmark_spec: The benchmark specification.
   """
   benchmark_spec.edw_service.Cleanup()
+
   edw_service_instance = benchmark_spec.edw_service
   client_interface = edw_service_instance.GetClientInterface()
-  client_interface.ExecuteQuery('delete_index_query')  
+  client_interface.ExecuteQuery('delete_index_query')

--- a/perfkitbenchmarker/linux_benchmarks/edw_create_index_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/edw_create_index_benchmark.py
@@ -114,7 +114,7 @@ def Prepare(benchmark_spec):
   any(vm.PushDataFile(query_loc) for query_loc in query_locations)
 
 
-# Check if there's no index already created. If so, issue a command to delete the index and keep
+# Check if there's an index already created. If so, issue a command to delete the index and keep
 # checking until index is deleted or timeout
 def ensure_no_index(client_interface):
   start_time = time.time()
@@ -123,7 +123,7 @@ def ensure_no_index(client_interface):
     time_elapsed = time.time() - start_time
     if time_elapsed > timeout:
       logging.error("Timed out waiting for index to be deleted.")
-      # TODO: how to stop the benchmark
+      # TODO: find a way to stop the benchmark in case of timeout
       break
     _, metadata = client_interface.ExecuteQuery('verify_no_index_query')
     if metadata and metadata.get('rows_returned', 0) > 0:
@@ -151,8 +151,8 @@ def measure_building_time(client_interface, results):
       results.append(sample.Sample('search_index_available_time', time_elapsed, 'seconds', metadata))
       break
     if time_elapsed > timeout:
-      logging.error("Timed out waiting for index to be fully created.")
-      # TODO: how to stop the benchmark
+      logging.error("Timed out waiting for index to fully cover the table.")
+      # TODO: find a way to stop the benchmark in case of timeout
       break
     else:
       time.sleep(1) 

--- a/perfkitbenchmarker/linux_benchmarks/edw_create_index_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/edw_create_index_benchmark.py
@@ -78,7 +78,7 @@ def Prepare(benchmark_spec: bm_spec.BenchmarkSpec) -> None:
   )
   edw_service_instance.GetClientInterface().Prepare('edw_common')
 
-  query_locations = [
+  query_locations: list[str] = [
       os.path.join(FLAGS.edw_index_creation_query_dir, query)
       for query in FLAGS.edw_power_queries.split(',')
   ]

--- a/perfkitbenchmarker/linux_benchmarks/edw_create_index_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/edw_create_index_benchmark.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""TODO
+"""
 
 Run command:
+
+BigQuery:
 
 ./pkb.py \
 --cloud=GCP  \
@@ -24,18 +26,38 @@ Run command:
 --config_override=edw_create_index_benchmark.edw_service.cluster_identifier=p3rf-bq-search.search_index_dataset \
 --gcp_service_account=bigquery-testing-pkb@p3rf-bigquery-smallquery-slots.iam.gserviceaccount.com \
 --gcp_service_account_key_file=/home/shuninglin/p3rf-bq-search-050c6559ed66.json \
---edw_index_creation_query_dir=edw/bigquery/search_index/create_index \
---edw_index_deletion_query_dir=edw/bigquery/search_index/delete_index \
---edw_index_check_query_dir=edw/bigquery/search_index/check_index \
+--edw_index_creation_query_dir=edw/bigquery/search_index/CUJ1 \
+--edw_power_queries=verify_no_index_query,create_index_query,delete_index_query,check_index_coverage_query \
 --metadata=cloud:GCP \
 --project=p3rf-bq-search \
 --zones=us-central1-c 
+
+Snowflake:
+
+TODO: Add SF queries to query folder and set up SF tables.
+
+./pkb.py \
+--cloud=AWS \
+--benchmarks=edw_create_index_benchmark \
+--snowflake_client_interface=JDBC  \
+--config_override=edw_create_index_benchmark.edw_service.type=snowflake_aws \
+--config_override=edw_index_benchmark.edw_service.cluster_identifier= \
+--snowflake_database=SEARCH_INDEX \
+--snowflake_schema=INDEX_TEST \
+--snowflake_warehouse=XSMALL_TEST \
+--edw_index_creation_query_dir=edw/snowflake_aws/search_index/CUJ1 \
+--edw_power_queries=verify_no_index_query,create_index_query,delete_index_query,check_index_coverage_query \
+--metadata=cloud:AWS \
+--snowflake_jdbc_client_jar=/home/shuninglin/snowflake-jdbc-client-2.13-enterprise.jar \
+--machine_type=m4.large \
+--zones=us-west-2a
 """
 
 """Benchmark for creating an index in an EDW service."""
 
 import os
 import time
+import logging
 from absl import flags
 from perfkitbenchmarker import configs
 from perfkitbenchmarker import edw_service
@@ -57,20 +79,6 @@ edw_create_index_benchmark:
 
 flags.DEFINE_string(
     'edw_index_creation_query_dir',
-    '',
-    'Optional local directory containing all query files. '
-    'Can be absolute or relative to the executable.',
-)
-
-flags.DEFINE_string(
-    'edw_index_deletion_query_dir',
-    '',
-    'Optional local directory containing all query files. '
-    'Can be absolute or relative to the executable.',
-)
-
-flags.DEFINE_string(
-    'edw_index_check_query_dir',
     '',
     'Optional local directory containing all query files. '
     'Can be absolute or relative to the executable.',
@@ -99,14 +107,56 @@ def Prepare(benchmark_spec):
   )
   edw_service_instance.GetClientInterface().Prepare('edw_common')
 
-  query_location = os.path.join(FLAGS.edw_index_creation_query_dir, 'create_index_query')
-  vm.PushDataFile(query_location)
+  query_locations = [
+      os.path.join(FLAGS.edw_index_creation_query_dir, query)
+      for query in FLAGS.edw_power_queries.split(',')
+  ]
+  any(vm.PushDataFile(query_loc) for query_loc in query_locations)
 
-  query_location = os.path.join(FLAGS.edw_index_deletion_query_dir, 'delete_index_query')
-  vm.PushDataFile(query_location)
 
-  query_location = os.path.join(FLAGS.edw_index_check_query_dir, 'check_index_coverage_query')
-  vm.PushDataFile(query_location)
+# Check if there's no index already created. If so, issue a command to delete the index and keep
+# checking until index is deleted or timeout
+def ensure_no_index(client_interface):
+  start_time = time.time()
+  timeout = 30
+  while True:
+    time_elapsed = time.time() - start_time
+    if time_elapsed > timeout:
+      logging.error("Timed out waiting for index to be deleted.")
+      # TODO: how to stop the benchmark
+      break
+    _, metadata = client_interface.ExecuteQuery('verify_no_index_query')
+    if metadata and metadata.get('rows_returned', 0) > 0:
+      client_interface.ExecuteQuery('delete_index_query')
+    else:
+      break
+    time.sleep(1) 
+
+
+# Create the index
+def create_index(client_interface, results):
+  execution_time, metadata = client_interface.ExecuteQuery('create_index_query')
+  results.append(sample.Sample('search_index_creation_time', execution_time, 'seconds', metadata))
+
+
+# Check Index Coverage until it reaches 100, record the time of reaching 100.
+# Time out if it takes too long to reach 100
+def measure_building_time(client_interface, results):
+  start_time = time.time()
+  timeout = 120
+  while True:
+    _, metadata = client_interface.ExecuteQuery('check_index_coverage_query')
+    time_elapsed = time.time() - start_time
+    if metadata and metadata.get('rows_returned', 0) > 0:
+      results.append(sample.Sample('search_index_available_time', time_elapsed, 'seconds', metadata))
+      break
+    if time_elapsed > timeout:
+      logging.error("Timed out waiting for index to be fully created.")
+      # TODO: how to stop the benchmark
+      break
+    else:
+      time.sleep(1) 
+
 
 def Run(benchmark_spec):
   """Runs the benchmark and returns a list of samples.
@@ -121,31 +171,13 @@ def Run(benchmark_spec):
 
   edw_service_instance = benchmark_spec.edw_service
   client_interface = edw_service_instance.GetClientInterface()
-  vm = benchmark_spec.vms[0]
 
-  # Delete Index If Exists
-  execution_time, metadata = client_interface.ExecuteQuery('delete_index_query')
-  results.append(sample.Sample('search_index_deletion_time', execution_time, 'seconds', metadata))
+  ensure_no_index(client_interface)
 
-  execution_time, metadata = client_interface.ExecuteQuery('create_index_query')
-  results.append(sample.Sample('search_index_creation_time', execution_time, 'seconds', metadata))
+  create_index(client_interface, results)
 
-  # Check Index Coverage until the index has been created
-  start_time = time.time()
-  timeout = 120
-  while True:
-    execution_time, metadata = client_interface.ExecuteQuery('check_index_coverage_query')
-    time_elapsed = time.time() - start_time
-    if metadata and metadata.get('rows_returned', 0) > 0:
-      results.append(sample.Sample('search_index_available_time', time_elapsed, 'seconds', metadata))
-      break
-    if time_elapsed > timeout:
-      print("Timed out waiting for index to be fully created.")
-      break
-    else:
-      time.sleep(1) 
+  measure_building_time(client_interface, results)
 
-  
   return results
 
 

--- a/perfkitbenchmarker/linux_benchmarks/edw_create_index_benchmark.py
+++ b/perfkitbenchmarker/linux_benchmarks/edw_create_index_benchmark.py
@@ -16,7 +16,12 @@
 TODO: Set up SF tables and queries and test if they work.
 """
 
-"""Benchmark for creating an index in an EDW service."""
+"""Benchmark for creating a search index in an EDW service.
+
+The benchmark first issues a command to create the search index on an existing table in an
+EDW service(BigQuery or Snowflake), then measures the time it takes for the index to fully cover the table.
+ 
+"""
 
 import os
 import time


### PR DESCRIPTION
- Set up a dedicated BQ table(100GB) for CUJ1 benchmark and modify BQ queries to use the dedicated table
- Added a query to verify no index on benchmark start
- Reorganize CUJ1 benchmark code, abstract logics in run into several functions.
- Reorganize query repo structure, now organize by CUJ(because we will use different tables for different CUJs. Question: Do we want to find a way to dynamically create queries based on table name rather than relying on hardcoding all queries?)

Tested with a PKB run using command below, generated correct result(`search_index_available_time` is 52~53 seconds, consistent with the numbers we've been observing)
```
./pkb.py \
--cloud=GCP  \
--benchmarks=edw_create_index_benchmark \
--bq_client_interface=PYTHON  \
--config_override=edw_create_index_benchmark.edw_service.type=bigquery \
--config_override=edw_create_index_benchmark.edw_service.cluster_identifier=p3rf-bq-search.search_index_dataset \
--gcp_service_account=bigquery-testing-pkb@p3rf-bigquery-smallquery-slots.iam.gserviceaccount.com \
--gcp_service_account_key_file=/home/shuninglin/p3rf-bq-search-050c6559ed66.json \
--edw_index_creation_query_dir=edw/bigquery/search_index/CUJ1 \
--edw_power_queries=verify_no_index_query,create_index_query,delete_index_query,check_index_coverage_query \
--metadata=cloud:GCP \
--project=p3rf-bq-search \
--zones=us-central1-c 
```